### PR TITLE
Support for array values

### DIFF
--- a/wp-graphql-meta-query.php
+++ b/wp-graphql-meta-query.php
@@ -254,6 +254,19 @@ class MetaQuery {
 					'name'  => 'NOT_EXISTS',
 					'value' => 'NOT EXISTS',
 				],
+				'REGEXP'                     => [
+					'name'  => 'REGEXP',
+					'value' => 'REGEXP',
+				],
+				'NOT_REGEXP'                     => [
+					'name'  => 'NOT_REGEXP',
+					'value' => 'NOT REGEXP',
+				],
+				'RLIKE'                     => [
+					'name'  => 'RLIKE',
+					'value' => 'RLIKE',
+				],
+			]
 			]
 		] );
 
@@ -264,7 +277,7 @@ class MetaQuery {
 					'description' => __( 'Custom field key', 'wp-graphql' ),
 				],
 				'value'   => [
-					'type'        => ['String','list_of' => 'String'],
+					'type'        => 'String',
 					'description' => __( 'Custom field value', 'wp-graphql' ),
 				],
 				'compare' => [

--- a/wp-graphql-meta-query.php
+++ b/wp-graphql-meta-query.php
@@ -254,19 +254,18 @@ class MetaQuery {
 					'name'  => 'NOT_EXISTS',
 					'value' => 'NOT EXISTS',
 				],
-				'REGEXP'                     => [
-					'name'  => 'REGEXP',
-					'value' => 'REGEXP',
+				'REXEXP'               => [
+					'name'  => 'REXEXP',
+					'value' => 'REXEXP',
 				],
-				'NOT_REGEXP'                     => [
-					'name'  => 'NOT_REGEXP',
-					'value' => 'NOT REGEXP',
+				'NOT_REXEXP'           => [
+					'name'  => 'NOT_REXEXP',
+					'value' => 'NOT REXEXP',
 				],
-				'RLIKE'                     => [
+				'RLIKE'               => [
 					'name'  => 'RLIKE',
 					'value' => 'RLIKE',
 				],
-			]
 			]
 		] );
 

--- a/wp-graphql-meta-query.php
+++ b/wp-graphql-meta-query.php
@@ -264,7 +264,7 @@ class MetaQuery {
 					'description' => __( 'Custom field key', 'wp-graphql' ),
 				],
 				'value'   => [
-					'type'        => 'String',
+					'type'        => ['String','list_of' => 'String'],
 					'description' => __( 'Custom field value', 'wp-graphql' ),
 				],
 				'compare' => [


### PR DESCRIPTION
meta_query must support array values in order to make 'IN', 'NOT IN', 'BETWEEN', or 'NOT BETWEEN' queries