### PR TITLE
Update to work with latest WPGraphQL (BREAKING)

### DIFF
--- a/wp-graphql-meta-query.php
+++ b/wp-graphql-meta-query.php
@@ -6,7 +6,7 @@
  * or newer.
  * Author: Jason Bahl
  * Author URI: http://www.wpgraphql.com
- * Version: 0.1.1
+ * Version: 0.2.0
  * Text Domain: wp-graphql-meta-query
  * Requires at least: 4.7.0
  * Tested up to: 4.7.1
@@ -82,7 +82,7 @@ class MetaQuery {
 
 		// Plugin version.
 		if ( ! defined( 'WPGRAPHQL_METAQUERY_VERSION' ) ) {
-			define( 'WPGRAPHQL_METAQUERY_VERSION', '0.1.1' );
+			define( 'WPGRAPHQL_METAQUERY_VERSION', '0.2.0' );
 		}
 
 		// Plugin Folder Path.

--- a/wp-graphql-meta-query.php
+++ b/wp-graphql-meta-query.php
@@ -58,6 +58,9 @@ class MetaQuery {
 		 */
 		add_filter( 'graphql_input_fields', [ $this, 'add_input_fields' ], 10, 4 );
 
+		// Register Tax Query Types
+		add_action( get_graphql_register_action(), [ $this, 'register_types' ], 10, 1 );
+
 		/**
 		 * Filter the $allowed_custom_args for the PostObjectsConnectionResolver to map the
 		 * metaQuery input to WP_Query terms
@@ -138,9 +141,8 @@ class MetaQuery {
 	 */
 	public function add_input_fields( $fields, $type_name, $config, $type_registry ) {
 		if ( isset( $config['queryClass'] ) && 'WP_Query' === $config['queryClass'] ) {
-			$this->register_types( $type_name, $type_registry );
 			$fields['metaQuery'] = [
-				'type' => $type_name . 'MetaQuery',
+				'type' => 'MetaQuery',
 			];
 		}
 
@@ -148,14 +150,13 @@ class MetaQuery {
 	}
 
 	/**
-	 * @param              $type_name
 	 * @param TypeRegistry $type_registry
 	 *
 	 * @throws \Exception
 	 */
-	public function register_types( $type_name, TypeRegistry $type_registry ) {
+	public function register_types( TypeRegistry $type_registry ) {
 
-		$type_registry->register_enum_type( $type_name . 'MetaTypeEnum', [
+		$type_registry->register_enum_type( 'MetaTypeEnum', [
 			'values' => [
 				'NUMERIC' => [
 					'name'  => 'NUMERIC',
@@ -196,7 +197,7 @@ class MetaQuery {
 			]
 		] );
 
-		$type_registry->register_enum_type( $type_name . 'MetaCompareEnum', [
+		$type_registry->register_enum_type( 'MetaCompareEnum', [
 			'values' => [
 				'EQUAL_TO'                 => [
 					'name'  => 'EQUAL_TO',
@@ -257,7 +258,7 @@ class MetaQuery {
 			]
 		] );
 
-		$type_registry->register_input_type( $type_name . 'MetaArray', [
+		$type_registry->register_input_type( 'MetaArray', [
 			'fields' => [
 				'key'     => [
 					'type'        => 'String',
@@ -268,24 +269,24 @@ class MetaQuery {
 					'description' => __( 'Custom field value', 'wp-graphql' ),
 				],
 				'compare' => [
-					'type'        => $type_name . 'MetaCompareEnum',
+					'type'        => 'MetaCompareEnum',
 					'description' => __( 'Custom field value', 'wp-graphql' ),
 				],
 				'type'    => [
-					'type'        => $type_name . 'MetaTypeEnum',
+					'type'        => 'MetaTypeEnum',
 					'description' => __( 'Custom field value', 'wp-graphql' ),
 				],
 			]
 		] );
 
-		$type_registry->register_input_type( $type_name . 'MetaQuery', [
+		$type_registry->register_input_type( 'MetaQuery', [
 			'fields' => [
 				'relation'  => [
 					'type' => 'RelationEnum',
 				],
 				'metaArray' => [
 					'type' => [
-						'list_of' => $type_name . 'MetaArray',
+						'list_of' => 'MetaArray',
 					],
 				],
 			]


### PR DESCRIPTION
Fixed the wp-graphq-meta-query to work with latest wp-graphql (v1.27.0) the same as @jasonbahl fixed wp-graphql-tax-query in here: https://github.com/wp-graphql/wp-graphql-tax-query/pull/32/files

I didn't test this quite thoroughly (only that it works in our use cases), but this probably has same kind of breaking changes as wp-graphql-tax-query [had](https://github.com/wp-graphql/wp-graphql-tax-query/pull/32#issue-1305271626). Apparently these:

- `RootQueryToPostConnectionWhereArgsMetaQuery` is now `MetaQuery`
- `RootQueryToPostConnectionWhereArgsMetaArray` is now `MetaArray`
- `ContentTypeToContentNodeConnectionWhereArgsMetaTypeEnum` is now `MetaTypeEnum`
- `ContentTypeToContentNodeConnectionWhereArgsMetaCompareEnum` is now `MetaCompareEnum`